### PR TITLE
Improve mobile UX with bottom tab navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,8 +48,31 @@
                 Upcoming Events
                 <span id="event-count" class="event-count" hidden></span>
             </h2>
-            <ul id="event-list" aria-live="polite"></ul>
+            <ul id="event-list" aria-live="polite">
+                <li class="no-events">Loading events&hellip;</li>
+            </ul>
         </aside>
     </main>
+
+    <!-- Tab bar — visible on mobile only, hidden via CSS on desktop -->
+    <nav class="mobile-nav" aria-label="View">
+        <button class="mobile-tab is-active" data-target="event-list-container" aria-selected="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <line x1="9" y1="6" x2="20" y2="6"/><line x1="9" y1="12" x2="20" y2="12"/><line x1="9" y1="18" x2="20" y2="18"/>
+                <circle cx="4" cy="6" r="1.5" fill="currentColor" stroke="none"/>
+                <circle cx="4" cy="12" r="1.5" fill="currentColor" stroke="none"/>
+                <circle cx="4" cy="18" r="1.5" fill="currentColor" stroke="none"/>
+            </svg>
+            <span>Upcoming</span>
+        </button>
+        <button class="mobile-tab" data-target="calendar-container" aria-selected="false">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+                <line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/>
+                <line x1="3" y1="10" x2="21" y2="10"/>
+            </svg>
+            <span>Calendar</span>
+        </button>
+    </nav>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -84,7 +84,7 @@ document.addEventListener('DOMContentLoaded', function () {
         upcomingEvents = events
             .filter(e => new Date(e.start) >= now)
             .sort((a, b) => new Date(a.start) - new Date(b.start))
-            .slice(0, 7);
+            .slice(0, 10);
 
         countEl.textContent = upcomingEvents.length || '';
         countEl.hidden = upcomingEvents.length === 0;
@@ -185,4 +185,36 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     calendar.render();
+
+    // ── Mobile tab switching ──────────────────────────────────────────────
+    if (window.innerWidth <= 768) {
+        const calendarPanel = document.getElementById('calendar-container');
+        const listPanel     = document.getElementById('event-list-container');
+        const tabs          = document.querySelectorAll('.mobile-tab');
+
+        // Default: show upcoming list, hide calendar
+        calendarPanel.classList.add('panel-hidden');
+
+        tabs.forEach(tab => {
+            tab.addEventListener('click', function () {
+                const targetId = this.dataset.target;
+
+                tabs.forEach(t => {
+                    t.classList.remove('is-active');
+                    t.setAttribute('aria-selected', 'false');
+                });
+                this.classList.add('is-active');
+                this.setAttribute('aria-selected', 'true');
+
+                calendarPanel.classList.toggle('panel-hidden', targetId !== 'calendar-container');
+                listPanel.classList.toggle('panel-hidden',     targetId !== 'event-list-container');
+
+                if (targetId === 'calendar-container') {
+                    // Wait two frames for the panel to paint before FullCalendar
+                    // recalculates its dimensions; avoids a 0-height render.
+                    requestAnimationFrame(() => requestAnimationFrame(() => calendar.updateSize()));
+                }
+            });
+        });
+    }
 });

--- a/style.css
+++ b/style.css
@@ -297,35 +297,112 @@ header h1 {
     margin: 8px 0;
 }
 
+/* ===== MOBILE NAV (hidden on desktop) ===== */
+.mobile-nav { display: none; }
+
 /* ===== MOBILE ===== */
 @media (max-width: 768px) {
-    body { height: auto; min-height: 100vh; }
-
-    .container {
+    /* Stack header → content → tab bar with flex column */
+    body {
+        display: flex;
         flex-direction: column;
-        padding: 12px;
-        gap: 12px;
-        overflow: visible;
+        height: 100vh;
+        height: 100dvh; /* excludes browser chrome on mobile */
+        overflow: hidden;
     }
 
-    #calendar-container {
-        flex: none;
-        height: 70vh;
-        min-height: 380px;
+    header { flex-shrink: 0; }
+
+    /* Content area fills remaining space between header and tab bar */
+    .container {
+        flex: 1;
+        min-height: 0;
+        padding: 0;
+        gap: 0;
+        overflow: hidden;
+        position: relative;
+        max-width: none;
+        margin: 0;
     }
 
+    /* Each panel is absolutely positioned to fill the content area */
+    #calendar-container,
     #event-list-container {
-        flex: none;
+        position: absolute;
+        inset: 0;
+        border-radius: 0;
+        border: none;
+        box-shadow: none;
         min-width: 0;
         max-width: none;
         width: 100%;
+        height: auto;
         max-height: none;
     }
 
+    #calendar-container {
+        display: flex;
+        flex-direction: column;
+        padding: 12px;
+        gap: 10px;
+        overflow: hidden;
+    }
+
+    #event-list-container {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+        padding: 20px 16px;
+    }
+
+    /* Used by JS to hide the inactive panel */
+    .panel-hidden { display: none !important; }
+
+    /* Tap feedback on event list items */
+    #event-list li:active { background: var(--bg); }
+
+    /* ===== MOBILE NAV BAR ===== */
+    .mobile-nav {
+        display: flex;
+        flex-shrink: 0;
+        background: var(--surface);
+        border-top: 1px solid var(--border);
+        box-shadow: 0 -1px 8px rgba(0, 0, 0, 0.06);
+        /* Respect iPhone home-indicator safe area */
+        padding-bottom: env(safe-area-inset-bottom, 0);
+    }
+
+    .mobile-tab {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 3px;
+        padding: 10px 4px;
+        min-height: 56px;
+        font-family: var(--font);
+        font-size: 0.7rem;
+        font-weight: 500;
+        color: var(--text-muted);
+        background: none;
+        border: none;
+        cursor: pointer;
+        transition: color var(--transition);
+        -webkit-tap-highlight-color: transparent;
+    }
+
+    .mobile-tab.is-active { color: var(--primary); }
+
+    /* FullCalendar toolbar tweaks for narrow screens */
     .fc .fc-toolbar { flex-wrap: wrap; gap: 8px; }
 
     .fc .fc-toolbar .fc-toolbar-chunk {
         display: flex;
         justify-content: center;
+    }
+
+    .fc .fc-button {
+        padding: 6px 10px !important;
+        font-size: 0.8rem !important;
     }
 }


### PR DESCRIPTION
Replace the stacked scroll layout on mobile with a proper app-like bottom tab bar:

- Two tabs: Upcoming (default) and Calendar
- Each tab is a full-screen absolute-positioned panel that fills the space between the header and the tab bar — no scrolling past a cramped calendar grid to reach the event list
- Upcoming tab is selected by default; Calendar tab hides until tapped
- calendar.updateSize() called via double-rAF when Calendar tab is activated, ensuring FullCalendar fills the panel correctly
- Safe-area padding on the tab bar for iPhone home-indicator devices
- Tap feedback (active state) on upcoming event list items
- FullCalendar toolbar buttons made smaller and wrappable on narrow screens
- Body switches to flex-column + 100dvh on mobile (excludes browser chrome) so panels always fit the visible viewport
- Upcoming event count increased from 7 to 10 (better use of full-screen panel)
- Initial "Loading events…" placeholder in event list while data fetches

https://claude.ai/code/session_01SYieEHkwc1Mpga5hhvBdkk